### PR TITLE
Feature/keyboard navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ An accessible, localized, full featured media player with Vuetifyjs
 -   [Supported Events](#supported-vuetifyplayer-events)
 -   [Supported Slots](#supported-vuetifyplayer-slots)
 -   [Captions](#captions)
+-   [Supported Keyboard Shortcuts](#supported-keyboard-shortcuts)
 -   [License](#license)
 
 ---
@@ -216,16 +217,14 @@ See [Full media `src` structure for where the ads array is placed](#full-media-s
 | `playlistmenu`                 | `Boolean` | true \| false                                      | true                          | Show the playlist menu if there's multiple videos                                                                                                                                         |
 | `playlistautoadvance`          | `Boolean` | true \| false                                      | true                          | Play the next source group                                                                                                                                                                |
 | `playbackrates`                | `Array`   | [`array of numbers`]                               | [0.5, 1, 1.5, 2]              | Default playback speeds. Anything below 0.25 and above 4 will make cause audio distortion                                                                                                 |
-| `captions-expanded`            | `Boolean` | true \| false                                      | undefined                     | Supports `.sync`. The initial state of the captions transcript being expanded.                                                                                                            | 
-| `captions-hide-expand`         | `Boolean` | true \| false                                      | true                          | Show / allow the captions transcript expand button for users                                                                                                                              | 
-| `captions-paragraph-view`      | `Boolean` | true \| false                                      | undefined                     | Supports `.sync`. The initial state of the captions transcript paragraph view                                                                                                             | 
-| `captions-hide-paragraph-view` | `Boolean` | true \| false                                      | false                         | Allow the captions transcript paragraph view for users                                                                                                                                    | 
-| `captions-autoscroll`          | `Boolean` | true \| false                                      | false                         | Supports `.sync`. The initial state for the captions transcript autoscroll state                                                                                                          | 
-| `captions-hide-autoscroll`     | `Boolean` | true \| false                                      | undefined                     | Allow users to enable / disable captions transcript autoscrolling                                                                                                                         | 
-| `captions-hide-close`          | `Boolean` | true \| false                                      | false                         | Allow users to show / hide the captions transcript box                                                                                                                                    | 
-| `captions-visible`             | `Boolean` | true \| false                                      | false                         | Supports `.sync`. The initial state for the captions transcript visibility                                                                                                                | 
-
-
+| `captions-expanded`            | `Boolean` | true \| false                                      | undefined                     | Supports `.sync`. The initial state of the captions transcript being expanded.                                                                                                            |
+| `captions-hide-expand`         | `Boolean` | true \| false                                      | true                          | Show / allow the captions transcript expand button for users                                                                                                                              |
+| `captions-paragraph-view`      | `Boolean` | true \| false                                      | undefined                     | Supports `.sync`. The initial state of the captions transcript paragraph view                                                                                                             |
+| `captions-hide-paragraph-view` | `Boolean` | true \| false                                      | false                         | Allow the captions transcript paragraph view for users                                                                                                                                    |
+| `captions-autoscroll`          | `Boolean` | true \| false                                      | false                         | Supports `.sync`. The initial state for the captions transcript autoscroll state                                                                                                          |
+| `captions-hide-autoscroll`     | `Boolean` | true \| false                                      | undefined                     | Allow users to enable / disable captions transcript autoscrolling                                                                                                                         |
+| `captions-hide-close`          | `Boolean` | true \| false                                      | false                         | Allow users to show / hide the captions transcript box                                                                                                                                    |
+| `captions-visible`             | `Boolean` | true \| false                                      | false                         | Supports `.sync`. The initial state for the captions transcript visibility                                                                                                                |
 
 ## Supported `<VuetifyPlayer>` Events
 
@@ -254,7 +253,7 @@ See [Full media `src` structure for where the ads array is placed](#full-media-s
 | `click:fullscreen`               | `true` \| `false` | When the fullscreen button is clicked. true on fullscreen, false on exiting fullscreen                               |
 | `click:pictureinpicture`         | `true` \| `false` | When the picture-in-picture button is clicked. true on enabled, false on disabled                                    |
 | `click:captions-expand`          | `true` \| `false` | When the expand captions button is clicked. true on expanded, false on collapsed                                     |
-| `click:captions-paragraph-view`  | `true` \| `false` | When the view as paragraph button is clicked. true when viewing as a paragraph, false when viewing as timed captions |                                                                                                                                                 
+| `click:captions-paragraph-view`  | `true` \| `false` | When the view as paragraph button is clicked. true when viewing as a paragraph, false when viewing as timed captions |
 | `click:captions-autoscroll`      | `true` \| `false` | When the autoscroll captions button is clicked. true on autoscrolling otherwise false                                |
 | `click:captions-close`           | `true` \| `false` | When the c;pse captions button is clicked. true on closed, false on visible                                          |
 | `update:captions-expanded`       | `true` \| `false` | When the captions expand state is updated                                                                            |
@@ -262,13 +261,11 @@ See [Full media `src` structure for where the ads array is placed](#full-media-s
 | `update:captions-autoscroll`     | `true` \| `false` | When the captions autoscroll state is updated                                                                        |
 | `update:captions-visible`        | `true` \| `false` | When the captions visible state is updated                                                                           |
 
-
 ## Supported `<VuetifyPlayer>` Slots
 
-| Slot name                        | Attributes        | Description                                                                                                          |
-| -------------------------------- | ----------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `no-source`                      | `none`            | Displayed over the media skeleton loader when no media source is configured                                          |
-
+| Slot name   | Attributes | Description                                                                 |
+| ----------- | ---------- | --------------------------------------------------------------------------- |
+| `no-source` | `none`     | Displayed over the media skeleton loader when no media source is configured |
 
 ## Captions
 
@@ -289,6 +286,21 @@ This text will show up on a new line in the player.
 00:00:03.000 --> 00:00:5.999
 sentence here to break it up
 ```
+
+## Supported Keyboard Shortcuts
+
+| Key             | Action                  |
+| --------------- | ----------------------- |
+| `k`             | Toggle play / pause     |
+| `m`             | Toggle mute             |
+| `{Left Arrow}`  | Rewind 5 seconds        |
+| `{Right Arrow}` | Fast forward 5 seconds  |
+| `j`             | Rewind 10 seconds       |
+| `l`             | Fast forward 10 seconds |
+| `{Up Arrow}`    | Increase volume by 10%  |
+| `{Down Arrow}`  | Decrease volume by 10%  |
+| `f`             | Toggle fullscreen       |
+| `c`             | Toggle closed captions  |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ An accessible, localized, full featured media player with Vuetifyjs
 -   [Define ads / preroll / postroll](#the-ads-array)
 -   [Supported Attributes](#supported-vuetifyplayer-attributes)
 -   [Supported Events](#supported-vuetifyplayer-events)
+-   [Supported Slots](#supported-vuetifyplayer-slots)
 -   [Captions](#captions)
 -   [License](#license)
 
@@ -260,6 +261,14 @@ See [Full media `src` structure for where the ads array is placed](#full-media-s
 | `update:captions-paragraph-view` | `true` \| `false` | When the captions paragraph-view state is updated                                                                    |
 | `update:captions-autoscroll`     | `true` \| `false` | When the captions autoscroll state is updated                                                                        |
 | `update:captions-visible`        | `true` \| `false` | When the captions visible state is updated                                                                           |
+
+
+## Supported `<VuetifyPlayer>` Slots
+
+| Slot name                        | Attributes        | Description                                                                                                          |
+| -------------------------------- | ----------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `no-source`                      | `none`            | Displayed over the media skeleton loader when no media source is configured                                          |
+
 
 ## Captions
 

--- a/src/components/Media/CaptionsMenu.vue
+++ b/src/components/Media/CaptionsMenu.vue
@@ -123,6 +123,7 @@
 
             <div class="d-flex flex-grow-1">
                 <v-text-field
+                    id="captions-search"
                     v-model="search"
                     :label="t(language, 'captions.search')"
                     append-icon="mdi-magnify"

--- a/src/components/Media/Html5Player.vue
+++ b/src/components/Media/Html5Player.vue
@@ -1,7 +1,11 @@
 <template>
     <v-container>
         <v-row>
-            <v-col :cols="!options.expandedCaptions ? 12 : 6" class="pb-0 mb-0">
+            <v-col
+                ref="playerContainer"
+                :cols="!options.expandedCaptions ? 12 : 6"
+                class="pb-0 mb-0"
+            >
                 <div v-if="buffering" class="player-overlay">
                     <v-progress-circular
                         :size="50"
@@ -90,9 +94,7 @@
                                 <template #prepend>
                                     <!-- Play button -->
                                     <v-tooltip v-if="!showReplay" top>
-                                        <template
-                                            v-slot:activator="{ on, attrs }"
-                                        >
+                                        <template #activator="{ on, attrs }">
                                             <v-btn
                                                 small
                                                 text
@@ -129,9 +131,7 @@
 
                                     <!-- Replay button -->
                                     <v-tooltip v-if="showReplay" top>
-                                        <template
-                                            v-slot:activator="{ on, attrs }"
-                                        >
+                                        <template #activator="{ on, attrs }">
                                             <v-btn
                                                 small
                                                 text
@@ -160,9 +160,7 @@
                                         v-if="attributes.rewind && !activeAd"
                                         top
                                     >
-                                        <template
-                                            v-slot:activator="{ on, attrs }"
-                                        >
+                                        <template #activator="{ on, attrs }">
                                             <v-btn
                                                 small
                                                 text
@@ -196,9 +194,7 @@
                                         top
                                         offset-y
                                     >
-                                        <template
-                                            v-slot:activator="{ on, attrs }"
-                                        >
+                                        <template #activator="{ on, attrs }">
                                             <v-btn
                                                 small
                                                 text
@@ -241,9 +237,7 @@
 
                                     <!-- Volume -->
                                     <v-menu open-on-hover top offset-y>
-                                        <template
-                                            v-slot:activator="{ on, attrs }"
-                                        >
+                                        <template #activator="{ on, attrs }">
                                             <v-btn
                                                 small
                                                 text
@@ -312,9 +306,7 @@
 
                                     <!-- Fullscreen -->
                                     <v-tooltip v-if="fullscreenEnabled" top>
-                                        <template
-                                            v-slot:activator="{ on, attrs }"
-                                        >
+                                        <template #activator="{ on, attrs }">
                                             <v-btn
                                                 small
                                                 text
@@ -350,9 +342,7 @@
                                         "
                                         top
                                     >
-                                        <template
-                                            v-slot:activator="{ on, attrs }"
-                                        >
+                                        <template #activator="{ on, attrs }">
                                             <v-btn
                                                 small
                                                 text
@@ -384,9 +374,7 @@
                                         v-if="options.remoteplayback"
                                         top
                                     >
-                                        <template
-                                            v-slot:activator="{ on, attrs }"
-                                        >
+                                        <template #activator="{ on, attrs }">
                                             <v-btn
                                                 small
                                                 text
@@ -413,9 +401,7 @@
 
                                     <!-- Download -->
                                     <v-tooltip v-if="options.download" top>
-                                        <template
-                                            v-slot:activator="{ on, attrs }"
-                                        >
+                                        <template #activator="{ on, attrs }">
                                             <v-btn
                                                 small
                                                 text
@@ -806,7 +792,7 @@ export default {
         onFullscreen() {
             this.options.fullscreen = !document.fullscreenElement
             // Return the whole element to be fullscreened so the controls come with it
-            this.$emit('click:fullscreen', this.$el)
+            this.$emit('click:fullscreen', this.$refs.playerContainer)
         },
         onPictureInPicture() {
             //this.options.pip = !document.fullscreenElement;

--- a/src/components/Media/Html5Player.vue
+++ b/src/components/Media/Html5Player.vue
@@ -69,6 +69,7 @@
                 </video>
 
                 <div
+                    ref="controlsContainer"
                     class="controls-container"
                     v-if="attributes.controls"
                     @mouseover="onControlsHover"
@@ -190,9 +191,10 @@
                                             current.tracks &&
                                             current.tracks.length > 0
                                         "
+                                        :attach="$refs.controlsContainer"
                                         open-on-hover
-                                        top
                                         offset-y
+                                        top
                                     >
                                         <template #activator="{ on, attrs }">
                                             <v-btn
@@ -236,7 +238,12 @@
                                     </v-menu>
 
                                     <!-- Volume -->
-                                    <v-menu open-on-hover top offset-y>
+                                    <v-menu
+                                        :attach="$refs.controlsContainer"
+                                        open-on-hover
+                                        offset-y
+                                        top
+                                    >
                                         <template #activator="{ on, attrs }">
                                             <v-btn
                                                 small
@@ -423,7 +430,9 @@
                                         }}</span>
                                     </v-tooltip>
 
+                                    <!-- Settings -->
                                     <SettingsMenu
+                                        :attach="$refs.controlsContainer"
                                         :options="options"
                                         :attributes="attributes"
                                         :language="language"
@@ -1171,28 +1180,10 @@ export default {
     position: relative;
     top: -50px;
     margin-bottom: -40px;
-    overflow: hidden;
 }
 .controls {
     height: 40px;
     background: linear-gradient(rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.7));
-}
-.volume-slider {
-    position: relative;
-    right: -50px;
-    top: -180px;
-    height: 180px;
-    width: 50px;
-    margin-left: -50px;
-    padding-bottom: 10px;
-}
-.slider-active-area {
-    width: 50px;
-    height: 200px;
-    margin-right: -50px;
-    margin-bottom: -200px;
-    position: relative;
-    top: -160px; /* height of this - controls height */
 }
 .player-audio {
     height: 40px;

--- a/src/components/Media/PlaylistMenu.vue
+++ b/src/components/Media/PlaylistMenu.vue
@@ -2,33 +2,40 @@
     <v-card>
         <v-card-title>{{ t(language, 'playlist.up_next') }}</v-card-title>
         <v-card-text>
-            <v-list>
+            <v-list class="playlist-list">
                 <v-list-item-group v-model="sourceIndex">
-                    <v-list-item
+                    <v-tooltip
+                        bottom
                         v-for="(source, index) of playlist"
                         :key="index + 'playlistSources'"
-                        @click="onPlaylistSelect(index)"
                     >
-                        <v-list-item-icon>
-                            <v-avatar
-                                v-if="getPoster(source.poster, poster)"
-                                tile
+                        <template #activator="{ on, attrs }">
+                            <v-list-item
+                                class="pl-1"
+                                v-bind="attrs"
+                                v-on="on"
+                                @click="onPlaylistSelect(index)"
                             >
-                                <img :src="getPoster(source.poster, poster)" />
-                            </v-avatar>
-                            <v-skeleton-loader
-                                v-if="!getPoster(source.poster, poster)"
-                                class="ma-3"
-                                type="avatar"
-                                tile
-                            ></v-skeleton-loader>
-                        </v-list-item-icon>
-                        <v-list-item-content>
-                            <v-tooltip bottom>
-                                <template v-slot:activator="{ on, attrs }">
+                                <v-list-item-icon class="ma-2">
+                                    <v-avatar
+                                        v-if="getPoster(source.poster, poster)"
+                                        tile
+                                    >
+                                        <img
+                                            :src="
+                                                getPoster(source.poster, poster)
+                                            "
+                                        />
+                                    </v-avatar>
+                                    <v-skeleton-loader
+                                        v-if="!getPoster(source.poster, poster)"
+                                        class="ma-3"
+                                        type="avatar"
+                                        tile
+                                    ></v-skeleton-loader>
+                                </v-list-item-icon>
+                                <v-list-item-content>
                                     <div
-                                        v-bind="attrs"
-                                        v-on="on"
                                         class="text-lg-subtitle-1 text-truncate"
                                     >
                                         {{
@@ -36,16 +43,16 @@
                                             t(language, 'playlist.default_name')
                                         }}
                                     </div>
-                                </template>
-                                <span>
-                                    {{
-                                        source.name ||
-                                        t(language, 'playlist.default_name')
-                                    }}
-                                </span>
-                            </v-tooltip>
-                        </v-list-item-content>
-                    </v-list-item>
+                                </v-list-item-content>
+                            </v-list-item>
+                        </template>
+                        <span>
+                            {{
+                                source.name ||
+                                t(language, 'playlist.default_name')
+                            }}
+                        </span>
+                    </v-tooltip>
                 </v-list-item-group>
             </v-list>
         </v-card-text>
@@ -122,17 +129,8 @@ export default {
 </script>
 
 <style scoped>
-.captions-list {
-    max-height: 10em;
+.playlist-list {
+    max-height: 200px;
     overflow-y: scroll;
-    /* Fade the top/bottom 20% effect. The "red" mask is so the scrollbar doesn't get this effect*/
-    mask: linear-gradient(90deg, rgba(255, 0, 0, 0) 98%, rgba(255, 0, 0, 1) 98%),
-        linear-gradient(
-            0deg,
-            rgba(0, 0, 0, 0) 0%,
-            rgba(0, 0, 0, 1) 20%,
-            rgba(0, 0, 0, 1) 80%,
-            rgba(0, 0, 0, 0) 100%
-        );
 }
 </style>

--- a/src/components/Media/SettingsMenu.vue
+++ b/src/components/Media/SettingsMenu.vue
@@ -1,6 +1,6 @@
 <template>
     <!-- Settings -->
-    <v-menu top offset-y :close-on-content-click="false" nudge-left="100">
+    <v-menu :attach="attach" top left offset-y :close-on-content-click="false">
         <template #activator="{ on, attrs }">
             <v-btn small text v-bind="attrs" v-on="on">
                 <v-icon>mdi-cog</v-icon>
@@ -70,6 +70,7 @@ export default {
     components: {},
     props: {
         language: { type: String, required: false, default: 'en-US' },
+        attach: { type: [Object, Boolean], required: false, default: false },
         options: {
             type: Object,
             required: true,

--- a/src/components/Media/SettingsMenu.vue
+++ b/src/components/Media/SettingsMenu.vue
@@ -30,8 +30,8 @@
                 <v-list-item-title class="text-center">
                     <v-btn
                         small
-                        :disabled="options.playbackRateIndex === 0"
-                        @click="onPlaybackSpeed(options.playbackRateIndex - 1)"
+                        :disabled="state.playbackRateIndex === 0"
+                        @click="onPlaybackSpeed(state.playbackRateIndex - 1)"
                     >
                         <v-icon> mdi-clock-minus-outline </v-icon>
                         <span class="d-sr-only">{{
@@ -40,16 +40,16 @@
                     </v-btn>
                     <span class="pl-2 pr-2"
                         >{{
-                            attributes.playbackrates[options.playbackRateIndex]
+                            attributes.playbackrates[state.playbackRateIndex]
                         }}x</span
                     >
                     <v-btn
                         small
                         :disabled="
-                            options.playbackRateIndex >=
+                            state.playbackRateIndex >=
                             attributes.playbackrates.length - 1
                         "
-                        @click="onPlaybackSpeed(options.playbackRateIndex + 1)"
+                        @click="onPlaybackSpeed(state.playbackRateIndex + 1)"
                     >
                         <v-icon> mdi-clock-plus-outline </v-icon>
                         <span class="d-sr-only">{{
@@ -71,7 +71,7 @@ export default {
     props: {
         language: { type: String, required: false, default: 'en-US' },
         attach: { type: null, required: false, default: false },
-        options: {
+        state: {
             type: Object,
             required: true,
         },

--- a/src/components/Media/SettingsMenu.vue
+++ b/src/components/Media/SettingsMenu.vue
@@ -70,7 +70,7 @@ export default {
     components: {},
     props: {
         language: { type: String, required: false, default: 'en-US' },
-        attach: { type: [Object, Boolean], required: false, default: false },
+        attach: { type: null, required: false, default: false },
         options: {
             type: Object,
             required: true,

--- a/src/components/Media/SettingsMenu.vue
+++ b/src/components/Media/SettingsMenu.vue
@@ -80,7 +80,7 @@ export default {
         },
         captionsVisible: { type: Boolean, required: false, default: undefined },
     },
-    emits: [],
+    emits: ['update:captions-visible', 'change:playback-rate-index'],
     watch: {},
     computed: {},
     data() {

--- a/src/components/VuetifyPlayer.vue
+++ b/src/components/VuetifyPlayer.vue
@@ -24,7 +24,7 @@
                     :captions-hide-paragraph-view="captionsHideParagraphView"
                     :captions-autoscroll="captionsAutoscroll"
                     :captions-hide-autoscroll="captionsHideAutoscroll"
-                    :captions-visible="captionsVisible"
+                    :captions-visible.sync="captionsVisibleState"
                     @load="$emit('load', $event)"
                     @ended="onEnded"
                     @loadeddata="onLoadeddata"
@@ -52,9 +52,6 @@
                     "
                     @update:captions-autoscroll="
                         $emit('update:captions-autoscroll', $event)
-                    "
-                    @update:captions-visible="
-                        $emit('update:captions-visible', $event)
                     "
                     @click:fullscreen="onFullscreen"
                     @click:pictureinpicture="onPictureInPicture"
@@ -296,11 +293,25 @@ export default {
                 return 8
             }
         },
+        captionsVisibleState: {
+            get() {
+                if (typeof this.captionsVisible !== 'undefined') {
+                    return this.captionsVisible
+                } else {
+                    return this.captions.visible
+                }
+            },
+            set(v) {
+                this.$emit('update:captions-visible', v)
+                this.captions.visible = v
+            },
+        },
     },
     data() {
         return {
             sourceIndex: 0,
             captions: {
+                visible: true,
                 expanded: false,
             },
         }

--- a/src/i18n/en-US.js
+++ b/src/i18n/en-US.js
@@ -10,6 +10,7 @@ export default {
         next: 'Play next item in playlist',
     },
     player: {
+        not_configured: 'Media not configured',
         playback_speed: 'Playback Speed',
         playback_decrease: 'Decrease playback speed',
         playback_increase: 'Increase playback speed',

--- a/src/i18n/es-ES.js
+++ b/src/i18n/es-ES.js
@@ -10,6 +10,7 @@ export default {
         next: 'Reproducir el siguiente elemento en la lista de reproducción',
     },
     player: {
+        not_configured: 'Medios no configurados',
         playback_speed: 'Velocidad de reproducción',
         playback_decrease: 'Disminuir la velocidad de reproducción',
         playback_increase: 'Aumentar la velocidad de reproducción',

--- a/src/i18n/sv-SE.js
+++ b/src/i18n/sv-SE.js
@@ -10,6 +10,7 @@ export default {
         next: 'Spela nästa',
     },
     player: {
+        not_configured: 'Media inte konfigurerad',
         playback_speed: 'Uppspelningshastighet',
         playback_decrease: 'Minska uppspelningshastigheten',
         playback_increase: 'Öka uppspelningshastigheten',

--- a/tests/unit/SettingsMenu.spec.js
+++ b/tests/unit/SettingsMenu.spec.js
@@ -11,7 +11,7 @@ describe('SettingsMenu', () => {
         const wrapper = shallowMount(SettingsMenu, {
             mocks: defaultMocks,
             propsData: {
-                options: { playbackRateIndex: 0 },
+                state: { playbackRateIndex: 0 },
                 attributes: {
                     captionsmenu: true,
                     playbackrates: [0.5, 1, 1.5, 2],

--- a/tests/unit/VuetifyPlayer.spec.js
+++ b/tests/unit/VuetifyPlayer.spec.js
@@ -48,4 +48,50 @@ describe('VuetifyPlayer', () => {
         expect(wrapper.vm.controls).toBeTruthy()
         expect(wrapper.vm.loop).toBeFalsy()
     })
+
+    test('VuetifyPlayer playlist of 2 items is marked as a playlist', () => {
+        const wrapper = shallowMount(VuetifyPlayer, {
+            mocks: defaultMocks,
+            propsData: {
+                playlist: [
+                    {
+                        sources: [
+                            {
+                                src: 'https://jest.jest/video.mp4',
+                                type: 'video.mp4',
+                            },
+                        ],
+                    },
+                    {
+                        sources: [
+                            {
+                                src: 'https://jest.jest/video.mp4',
+                                type: 'video.mp4',
+                            },
+                        ],
+                    },
+                ],
+            },
+        })
+        expect(wrapper.vm.showPlaylist).toEqual(true)
+    })
+
+    test('VuetifyPlayer playlist of 1 item is not marked as a playlist', () => {
+        const wrapper = shallowMount(VuetifyPlayer, {
+            mocks: defaultMocks,
+            propsData: {
+                playlist: [
+                    {
+                        sources: [
+                            {
+                                src: 'https://jest.jest/video.mp4',
+                                type: 'video.mp4',
+                            },
+                        ],
+                    },
+                ],
+            },
+        })
+        expect(wrapper.vm.showPlaylist).toEqual(false)
+    })
 })


### PR DESCRIPTION
## Changes

- Added keyboard events
- Fullscreen mode fix so it's fullscreening the correct element. Before it was cropping the video
- Fullscreen controls fix. The CC / Volume / Settings v-menu wasn't showing when in fullscreen before
- Fixed reactivity on fullscreen / remote playback / download attributes so they can be altered after mount
- Refactoring and bugfixes with attribute syncing
- Added no-source slot to VuetifyPlayer so the user can define custom text when the video configuration is missing
- Playlist / captions display fixes. Before the playlist would squish the video and could not be moved. Now the playlist is locked to the bottom of the video below the transcript
- Added documentation for new no-source slot and keyboard shortcuts

## `npm run test` Results

```
> @mindedge/vuetify-player@0.3.1 test
> vue-cli-service test:unit

 PASS  tests/unit/VuetifyPlayer.spec.js
 PASS  tests/unit/CaptionsMenu.spec.js
 PASS  tests/unit/Html5Player.spec.js
 PASS  tests/unit/PlaylistMenu.spec.js
 PASS  tests/unit/YoutubePlayer.spec.js
 PASS  tests/unit/SettingsMenu.spec.js

Test Suites: 6 passed, 6 total
Tests:       20 passed, 20 total
Snapshots:   0 total
Time:        1.101 s
Ran all test suites.
```

## `npm run lint` Results

```
> @mindedge/vuetify-player@0.3.1 lint
> vue-cli-service lint

 DONE  No lint errors found!
```