### PR TITLE
Bugfix/out of range captions

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,9 +266,10 @@ See [Full media `src` structure for where the ads array is placed](#full-media-s
 
 ## Supported `<VuetifyPlayer>` Slots
 
-| Slot name   | Attributes | Description                                                                 |
-| ----------- | ---------- | --------------------------------------------------------------------------- |
-| `no-source` | `none`     | Displayed over the media skeleton loader when no media source is configured |
+| Slot name   | Attributes | Description                                                                          |
+| ----------- | ---------- | ------------------------------------------------------------------------------------ |
+| `no-source` | `none`     | Displayed over the media skeleton loader when no media source is configured          |
+| `loading`   | `none`     | Displayed over the media skeleton loader when the playlist has changed via its props |
 
 ## Captions
 

--- a/src/components/Media/Html5Player.vue
+++ b/src/components/Media/Html5Player.vue
@@ -1164,10 +1164,23 @@ export default {
             this.player.currentTime = time
         },
         setCues(track) {
+            // Filter out any cues / active cues that start after the video has already ended
+            // This way we don't show captions that we can't skip to
+            const cues = Object.keys(track.cues)
+                .map((key) => track.cues[key])
+                .filter((c) => {
+                    return c.startTime < this.player.duration
+                })
+            const activeCues = Object.keys(track.activeCues)
+                .map((key) => track.activeCues[key])
+                .filter((c) => {
+                    return c.startTime < this.player.duration
+                })
+
             // Create reactive fields
             this.$set(this.captions, 'language', track.language)
-            this.$set(this.captions, 'cues', track.cues)
-            this.$set(this.captions, 'activeCues', track.activeCues)
+            this.$set(this.captions, 'cues', cues)
+            this.$set(this.captions, 'activeCues', activeCues)
 
             // Required so the v-model will actually update.
             this.captions.nonce = Math.random()

--- a/src/components/Media/Html5Player.vue
+++ b/src/components/Media/Html5Player.vue
@@ -1166,12 +1166,12 @@ export default {
         setCues(track) {
             // Filter out any cues / active cues that start after the video has already ended
             // This way we don't show captions that we can't skip to
-            const cues = Object.keys(track.cues)
+            const cues = Object.keys(track.cues || {})
                 .map((key) => track.cues[key])
                 .filter((c) => {
                     return c.startTime < this.player.duration
                 })
-            const activeCues = Object.keys(track.activeCues)
+            const activeCues = Object.keys(track.activeCues || {})
                 .map((key) => track.activeCues[key])
                 .filter((c) => {
                     return c.startTime < this.player.duration

--- a/src/i18n/en-US.js
+++ b/src/i18n/en-US.js
@@ -10,6 +10,7 @@ export default {
         next: 'Play next item in playlist',
     },
     player: {
+        loading: 'Loading...',
         not_configured: 'Media not configured',
         playback_speed: 'Playback Speed',
         playback_decrease: 'Decrease playback speed',

--- a/src/i18n/es-ES.js
+++ b/src/i18n/es-ES.js
@@ -10,6 +10,7 @@ export default {
         next: 'Reproducir el siguiente elemento en la lista de reproducción',
     },
     player: {
+        loading: 'Cargando...',
         not_configured: 'Medios no configurados',
         playback_speed: 'Velocidad de reproducción',
         playback_decrease: 'Disminuir la velocidad de reproducción',

--- a/src/i18n/sv-SE.js
+++ b/src/i18n/sv-SE.js
@@ -10,6 +10,7 @@ export default {
         next: 'Spela nästa',
     },
     player: {
+        loading: 'Laddar...',
         not_configured: 'Media inte konfigurerad',
         playback_speed: 'Uppspelningshastighet',
         playback_decrease: 'Minska uppspelningshastigheten',


### PR DESCRIPTION
## Changes

-  Filter out any cues / active cues that start after the video has already ended from the interactive captions menu
- Setup player auto-refresh on playlist changes
- Updated README to include new loading slot

## `npm run test` Results

```
Test Suites: 6 passed, 6 total
Tests:       21 passed, 21 total
Snapshots:   0 total
Time:        1.617 s
Ran all test suites.
```

## `npm run lint` Results

```
> @mindedge/vuetify-player@0.4.2 lint
> vue-cli-service lint

Browserslist: caniuse-lite is outdated. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
 DONE  No lint errors found!
```
