### PR TITLE
Bugfix/videos toolbar and timeline

### DIFF
--- a/src/components/Media/Html5Player.vue
+++ b/src/components/Media/Html5Player.vue
@@ -118,7 +118,8 @@
                                     <v-tooltip v-if="!state.replay" top>
                                         <template #activator="{ on, attrs }">
                                             <v-btn
-                                                small
+                                                class="controls--button"
+                                                x-small
                                                 text
                                                 v-bind="attrs"
                                                 v-on="on"
@@ -155,7 +156,8 @@
                                     <v-tooltip v-if="state.replay" top>
                                         <template #activator="{ on, attrs }">
                                             <v-btn
-                                                small
+                                                class="controls--button"
+                                                x-small
                                                 text
                                                 v-bind="attrs"
                                                 v-on="on"
@@ -184,8 +186,8 @@
                                     >
                                         <template #activator="{ on, attrs }">
                                             <v-btn
-                                                class="hide-mobile"
-                                                small
+                                                class="controls--button hide-mobile"
+                                                x-small
                                                 text
                                                 v-bind="attrs"
                                                 v-on="on"
@@ -220,7 +222,8 @@
                                     >
                                         <template #activator="{ on, attrs }">
                                             <v-btn
-                                                small
+                                                class="controls--button"
+                                                x-small
                                                 text
                                                 v-bind="attrs"
                                                 v-on="on"
@@ -268,7 +271,8 @@
                                     >
                                         <template #activator="{ on, attrs }">
                                             <v-btn
-                                                small
+                                                class="controls--button"
+                                                x-small
                                                 text
                                                 v-bind="attrs"
                                                 v-on="on"
@@ -336,7 +340,8 @@
                                     <v-tooltip v-if="allowFullscreen" top>
                                         <template #activator="{ on, attrs }">
                                             <v-btn
-                                                small
+                                                class="controls--button"
+                                                x-small
                                                 text
                                                 v-bind="attrs"
                                                 v-on="on"
@@ -372,7 +377,8 @@
                                     >
                                         <template #activator="{ on, attrs }">
                                             <v-btn
-                                                small
+                                                class="controls--button hide-mobile"
+                                                x-small
                                                 text
                                                 v-bind="attrs"
                                                 v-on="on"
@@ -401,7 +407,8 @@
                                     <v-tooltip v-if="allowRemotePlayback" top>
                                         <template #activator="{ on, attrs }">
                                             <v-btn
-                                                small
+                                                class="controls--button hide-mobile"
+                                                x-small
                                                 text
                                                 v-bind="attrs"
                                                 v-on="on"
@@ -428,7 +435,8 @@
                                     <v-tooltip v-if="allowDownload" top>
                                         <template #activator="{ on, attrs }">
                                             <v-btn
-                                                small
+                                                class="controls--button hide-mobile"
+                                                x-small
                                                 text
                                                 v-bind="attrs"
                                                 v-on="on"

--- a/src/components/Media/Html5Player.vue
+++ b/src/components/Media/Html5Player.vue
@@ -100,16 +100,26 @@
                                 dark
                                 :min="0"
                                 :max="scrub.max"
-                                :label="
-                                    filters.playerShortDuration(
-                                        percentToTimeSeconds(currentPercent)
-                                    ) +
-                                    ' / ' +
-                                    filters.playerShortDuration(player.duration)
-                                "
                                 inverse-label
                                 @change="onScrubTime"
                             >
+                                <template #label>
+                                    <div class="controls-timestamp--container">
+                                        <div class="controls-timestamp">
+                                            {{
+                                                filters.playerShortDuration(
+                                                    percentToTimeSeconds(
+                                                        currentPercent
+                                                    )
+                                                ) +
+                                                ' / ' +
+                                                filters.playerShortDuration(
+                                                    player.duration
+                                                )
+                                            }}
+                                        </div>
+                                    </div>
+                                </template>
                             </v-slider>
 
                             <div class="controls-buttons">
@@ -1348,6 +1358,15 @@ export default {
 @media (max-width: 600px) {
     .hide-mobile {
         display: none;
+    }
+    .controls-timestamp--container {
+        width: 0px;
+    }
+    .controls-timestamp {
+        width: 150px;
+        text-align: right;
+        margin-left: -150px;
+        margin-top: -25px;
     }
 }
 .controls-container {

--- a/src/components/Media/Html5Player.vue
+++ b/src/components/Media/Html5Player.vue
@@ -94,8 +94,10 @@
                     <v-slide-y-reverse-transition>
                         <div v-if="player && state.controls" class="controls">
                             <v-slider
-                                dark
                                 v-model="currentPercent"
+                                class="controls--slider"
+                                hide-details
+                                dark
                                 :min="0"
                                 :max="scrub.max"
                                 :label="
@@ -106,10 +108,12 @@
                                     filters.playerShortDuration(player.duration)
                                 "
                                 inverse-label
-                                @mousedown="onPause"
                                 @change="onScrubTime"
                             >
-                                <template #prepend>
+                            </v-slider>
+
+                            <div class="controls-buttons">
+                                <div class="controls-buttons--prepend">
                                     <!-- Play button -->
                                     <v-tooltip v-if="!state.replay" top>
                                         <template #activator="{ on, attrs }">
@@ -180,6 +184,7 @@
                                     >
                                         <template #activator="{ on, attrs }">
                                             <v-btn
+                                                class="hide-mobile"
                                                 small
                                                 text
                                                 v-bind="attrs"
@@ -199,9 +204,9 @@
                                             t(language, 'player.rewind_10')
                                         }}</span>
                                     </v-tooltip>
-                                </template>
+                                </div>
 
-                                <template #append>
+                                <div class="controls-buttons--append">
                                     <!-- Closed Captions -->
                                     <v-menu
                                         v-if="
@@ -456,8 +461,8 @@
                                             onPlaybackSpeedChange
                                         "
                                     ></SettingsMenu>
-                                </template>
-                            </v-slider>
+                                </div>
+                            </div>
                         </div>
                     </v-slide-y-reverse-transition>
                 </div>
@@ -1079,7 +1084,6 @@ export default {
             // thousands of "targets" for long videos
             const scaleFactor = this.player.duration / this.scrub.max
             this.setTime(value * scaleFactor)
-            this.player.pause()
         },
         onCuechange(e) {
             if (e && e.srcElement && e.srcElement.track) {
@@ -1156,10 +1160,16 @@ export default {
             // this.$refs.player is a type of HTMLMediaElement
             // See https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement
             //this.player.media = this.$refs.player;
-            this.$emit('loadedmetadata', e)
-            this.player = this.$refs.player
-            this.player.volume = this.state.volume
-            this.$emit('volumechange', this.state.volume)
+            if (this.$refs.player) {
+                this.player = this.$refs.player
+                this.player.volume = this.state.volume
+                this.$emit('volumechange', this.state.volume)
+                this.$emit('loadedmetadata', e)
+            } else {
+                console.error(
+                    'Html5Player->onLoadedmetadata() but player not ready'
+                )
+            }
         },
         volumeChange(value) {
             // Value needs to be a decimal value between 0 and 1
@@ -1327,18 +1337,37 @@ export default {
 </script>
 
 <style scoped>
+@media (max-width: 600px) {
+    .hide-mobile {
+        display: none;
+    }
+}
 .controls-container {
-    height: 40px;
+    height: 80px;
     position: relative;
-    top: -50px;
-    margin-bottom: -40px;
+    top: -90px;
+    margin-bottom: -80px;
 }
 .controls {
-    height: 40px;
+    height: 80px;
     background: linear-gradient(rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.7));
 }
+.controls--slider {
+    width: 100%;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+}
+.controls-buttons {
+    display: flex;
+}
+.controls-buttons--prepend {
+    margin-right: auto;
+}
+.controls-buttons--append {
+    margin-left: auto;
+}
 .player-audio {
-    height: 40px;
+    height: 80px;
 }
 .player-video {
     max-height: 100%;

--- a/src/components/Media/SettingsMenu.vue
+++ b/src/components/Media/SettingsMenu.vue
@@ -2,7 +2,7 @@
     <!-- Settings -->
     <v-menu :attach="attach" top left offset-y :close-on-content-click="false">
         <template #activator="{ on, attrs }">
-            <v-btn small text v-bind="attrs" v-on="on">
+            <v-btn x-small text v-bind="attrs" v-on="on">
                 <v-icon>mdi-cog</v-icon>
                 <span class="d-sr-only">{{
                     t(language, 'player.toggle_settings')


### PR DESCRIPTION
## Changes

-  Rearranged video controls so the scrub bar is full-width and above the play/pause/settings buttons. This gives it more room for smaller screens. Also hide the rewind 10 seconds button on <600px screens. Finally made it so scrubbing the video doesn't automatically pause the video
- Set controls buttons to x-small to reduce padding so everything fits for small screens
- Push timestamps above scrub bar for very small screens

## `npm run test` Results

```
> @mindedge/vuetify-player@0.4.2 test
> vue-cli-service test:unit

 PASS  tests/unit/YoutubePlayer.spec.js
 PASS  tests/unit/SettingsMenu.spec.js
 PASS  tests/unit/PlaylistMenu.spec.js
 PASS  tests/unit/CaptionsMenu.spec.js
 PASS  tests/unit/Html5Player.spec.js
 PASS  tests/unit/VuetifyPlayer.spec.js

Test Suites: 6 passed, 6 total
Tests:       21 passed, 21 total
Snapshots:   0 total
Time:        1.372 s
Ran all test suites.
```

## `npm run lint` Results

```
> @mindedge/vuetify-player@0.4.2 lint
> vue-cli-service lint

 DONE  No lint errors found!
```
