### PR TITLE
0.4.4 -> Develop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@mindedge/vuetify-player",
-    "version": "0.4.3",
+    "version": "0.4.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@mindedge/vuetify-player",
-            "version": "0.4.3",
+            "version": "0.4.4",
             "license": "MIT",
             "dependencies": {
                 "@intlify/vue-i18n-loader": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mindedge/vuetify-player",
-    "version": "0.4.3",
+    "version": "0.4.4",
     "private": false,
     "description": "Accessible, localized, full featured media player with Vuetifyjs",
     "author": "Jacob Rogaishio",

--- a/src/components/Media/Html5Player.vue
+++ b/src/components/Media/Html5Player.vue
@@ -129,6 +129,7 @@
                                         <template #activator="{ on, attrs }">
                                             <v-btn
                                                 class="controls--button"
+                                                dark
                                                 x-small
                                                 text
                                                 v-bind="attrs"
@@ -167,6 +168,7 @@
                                         <template #activator="{ on, attrs }">
                                             <v-btn
                                                 class="controls--button"
+                                                dark
                                                 x-small
                                                 text
                                                 v-bind="attrs"
@@ -197,6 +199,7 @@
                                         <template #activator="{ on, attrs }">
                                             <v-btn
                                                 class="controls--button hide-mobile"
+                                                dark
                                                 x-small
                                                 text
                                                 v-bind="attrs"
@@ -233,6 +236,7 @@
                                         <template #activator="{ on, attrs }">
                                             <v-btn
                                                 class="controls--button"
+                                                dark
                                                 x-small
                                                 text
                                                 v-bind="attrs"
@@ -282,6 +286,7 @@
                                         <template #activator="{ on, attrs }">
                                             <v-btn
                                                 class="controls--button"
+                                                dark
                                                 x-small
                                                 text
                                                 v-bind="attrs"
@@ -351,6 +356,7 @@
                                         <template #activator="{ on, attrs }">
                                             <v-btn
                                                 class="controls--button"
+                                                dark
                                                 x-small
                                                 text
                                                 v-bind="attrs"
@@ -388,6 +394,7 @@
                                         <template #activator="{ on, attrs }">
                                             <v-btn
                                                 class="controls--button hide-mobile"
+                                                dark
                                                 x-small
                                                 text
                                                 v-bind="attrs"
@@ -418,6 +425,7 @@
                                         <template #activator="{ on, attrs }">
                                             <v-btn
                                                 class="controls--button hide-mobile"
+                                                dark
                                                 x-small
                                                 text
                                                 v-bind="attrs"
@@ -446,6 +454,7 @@
                                         <template #activator="{ on, attrs }">
                                             <v-btn
                                                 class="controls--button hide-mobile"
+                                                dark
                                                 x-small
                                                 text
                                                 v-bind="attrs"
@@ -1374,6 +1383,7 @@ export default {
     position: relative;
     top: -90px;
     margin-bottom: -80px;
+    overflow: hidden;
 }
 .controls {
     height: 80px;

--- a/src/components/Media/SettingsMenu.vue
+++ b/src/components/Media/SettingsMenu.vue
@@ -2,7 +2,7 @@
     <!-- Settings -->
     <v-menu :attach="attach" top left offset-y :close-on-content-click="false">
         <template #activator="{ on, attrs }">
-            <v-btn x-small text v-bind="attrs" v-on="on">
+            <v-btn dark x-small text v-bind="attrs" v-on="on">
                 <v-icon>mdi-cog</v-icon>
                 <span class="d-sr-only">{{
                     t(language, 'player.toggle_settings')

--- a/tests/unit/Html5Player.spec.js
+++ b/tests/unit/Html5Player.spec.js
@@ -1,4 +1,4 @@
-import { shallowMount } from '@vue/test-utils'
+import { shallowMount, mount } from '@vue/test-utils'
 import Vuetify from 'vuetify'
 import Vue from 'vue'
 import Html5Player from '../../src/components/Media/Html5Player.vue'
@@ -182,5 +182,92 @@ describe('Html5Player', () => {
             },
         })
         expect(wrapper.vm.src.ads).toBeTruthy()
+    })
+
+    test('Html5Player controls are available', () => {
+        const wrapper = mount(Html5Player, {
+            vuetify: new Vuetify(),
+            mocks: defaultMocks,
+            propsData: {
+                type: 'video',
+                attributes: {
+                    playbackrates: [1],
+                    controls: true,
+                },
+                src: {
+                    sources: [
+                        {
+                            src: 'https://domain.test/example.mp4',
+                            type: 'video/mp4',
+                        },
+                    ],
+                },
+            },
+        })
+
+        const controls = wrapper.vm.$el
+            .querySelector('.controls-container')
+            .querySelectorAll('button')
+
+        expect(controls.length).toEqual(6)
+    })
+
+    test('Html5Player controls have the play button', () => {
+        const wrapper = mount(Html5Player, {
+            vuetify: new Vuetify(),
+            mocks: defaultMocks,
+            propsData: {
+                type: 'video',
+                attributes: {
+                    playbackrates: [1],
+                    controls: true,
+                },
+                src: {
+                    sources: [
+                        {
+                            src: 'https://domain.test/example.mp4',
+                            type: 'video/mp4',
+                        },
+                    ],
+                },
+            },
+        })
+
+        const playButton = wrapper.vm.$el
+            .querySelector('.controls-container')
+            .querySelector('button i.mdi-play')
+
+        expect(playButton).toBeTruthy()
+    })
+
+    test('Html5Player controls are dark mode', () => {
+        const wrapper = mount(Html5Player, {
+            vuetify: new Vuetify(),
+            mocks: defaultMocks,
+            propsData: {
+                type: 'video',
+                attributes: {
+                    playbackrates: [1],
+                    controls: true,
+                },
+                src: {
+                    sources: [
+                        {
+                            src: 'https://domain.test/example.mp4',
+                            type: 'video/mp4',
+                        },
+                    ],
+                },
+            },
+        })
+
+        const controls = wrapper.vm.$el
+            .querySelector('.controls-container')
+            .querySelectorAll('button')
+
+        // Expect all the controls to be in dark mode
+        for (const control of controls) {
+            expect(control.classList.contains('theme--dark')).toBeTruthy()
+        }
     })
 })


### PR DESCRIPTION
## Changes

-   Version bump to 0.4.4
- Gave buttons dark mode attribute since they no longer inherit it from v-slider
- Added unit tests to Html5Player to ensure control buttons are always in dark mode aka white so they appear over the black background

## `npm run test` Results

```
Test Suites: 6 passed, 6 total
Tests:       24 passed, 24 total
Snapshots:   0 total
Time:        1.453 s
Ran all test suites.
```

## `npm run lint` Results

```
> @mindedge/vuetify-player@0.4.4 lint
> vue-cli-service lint

Browserslist: caniuse-lite is outdated. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
 DONE  No lint errors found!
```
