### PR TITLE
Develop -> Master for 0.4.6 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@mindedge/vuetify-player",
-    "version": "0.4.5",
+    "version": "0.4.6",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@mindedge/vuetify-player",
-            "version": "0.4.5",
+            "version": "0.4.6",
             "license": "MIT",
             "dependencies": {
                 "@intlify/vue-i18n-loader": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mindedge/vuetify-player",
-    "version": "0.4.5",
+    "version": "0.4.6",
     "private": false,
     "description": "Accessible, localized, full featured media player with Vuetifyjs",
     "author": "Jacob Rogaishio",

--- a/src/components/Media/Html5Player.vue
+++ b/src/components/Media/Html5Player.vue
@@ -1278,7 +1278,7 @@ export default {
                             // If this is left default / set to 100 then the above line
                             // Also set snapToLines to true otherwise if there's a line % in the vtt file the display will be relative and make the lines not aligned properly
                             this.player.textTracks[i].activeCues[0].line =
-                                -3 - numLines
+                                -4 - numLines
                             this.player.textTracks[i].activeCues[0].size = 99
                             this.player.textTracks[
                                 i


### PR DESCRIPTION
## Changes

-   Fixed integrated captions height offset when the controls are visible

## `npm run test` Results

```
Test Suites: 6 passed, 6 total
Tests:       24 passed, 24 total
Snapshots:   0 total
Time:        1.882 s
Ran all test suites.
```

## `npm run lint` Results

```
> @mindedge/vuetify-player@0.4.6 lint
> vue-cli-service lint

Browserslist: caniuse-lite is outdated. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
 DONE  No lint errors found!
```
