### PR TITLE
version bump to 0.4.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@mindedge/vuetify-player",
-    "version": "0.4.7",
+    "version": "0.4.8",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@mindedge/vuetify-player",
-            "version": "0.4.7",
+            "version": "0.4.8",
             "license": "MIT",
             "dependencies": {
                 "@intlify/vue-i18n-loader": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mindedge/vuetify-player",
-    "version": "0.4.7",
+    "version": "0.4.8",
     "private": false,
     "description": "Accessible, localized, full featured media player with Vuetifyjs",
     "author": "Jacob Rogaishio",


### PR DESCRIPTION
## Changes

-   Change 1

## `npm run test` Results

```
results
```

## `npm run lint` Results

```
results
```
