### PR TITLE
Hotfix/0.4.9 -> Develop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@mindedge/vuetify-player",
-    "version": "0.4.8",
+    "version": "0.4.9",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@mindedge/vuetify-player",
-            "version": "0.4.8",
+            "version": "0.4.9",
             "license": "MIT",
             "dependencies": {
                 "@intlify/vue-i18n-loader": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mindedge/vuetify-player",
-    "version": "0.4.8",
+    "version": "0.4.9",
     "private": false,
     "description": "Accessible, localized, full featured media player with Vuetifyjs",
     "author": "Jacob Rogaishio",

--- a/src/components/Media/Html5Player.vue
+++ b/src/components/Media/Html5Player.vue
@@ -65,6 +65,7 @@
                     @abort="$emit('abort', $event)"
                     @focusin="$emit('focusin', $event)"
                     @focusout="$emit('focusout', $event)"
+                    @ratechange="onPlayerSpeedChange"
                 >
                     <source
                         v-for="(source, index) of current.sources"
@@ -1008,6 +1009,19 @@ export default {
                         this.$emit('trackchange', this.player.textTracks[i])
                     }
                 }
+            }
+        },
+        onPlayerSpeedChange(e) {
+            // If the player set its own playback rate (like during reloads) then we need to re-set it to the pre-chosen value
+            // The below checks if there's a mismatch between the player and what we set the current rate to be
+            if (
+                e &&
+                e.target &&
+                e.target.playbackRate &&
+                e.target.playbackRate !==
+                    this.attributes.playbackrates[this.state.playbackRateIndex]
+            ) {
+                this.onPlaybackSpeedChange(this.state.playbackRateIndex)
             }
         },
         onPlaybackSpeedChange(index) {


### PR DESCRIPTION
Fixes to playback rate changes from the player itself. Added a check to always revert to the last known playback speed if the player changes itself like on reloads / replays

## Changes

-   Change 1

## `npm run test` Results

```
Test Suites: 6 passed, 6 total
Tests:       24 passed, 24 total
Snapshots:   0 total
Time:        1.57 s
Ran all test suites.
```

## `npm run lint` Results

```
> @mindedge/vuetify-player@0.4.8 lint
> vue-cli-service lint

 DONE  No lint errors found!
```
