### PR TITLE
Added play icon when the video is at 0% to be clear that the video player can be interacted with

### DIFF
--- a/src/components/Media/Html5Player.vue
+++ b/src/components/Media/Html5Player.vue
@@ -22,8 +22,22 @@
                     class="player-overlay"
                 >
                     <div class="player-overlay--icon">
-                        <v-icon class="player-overlay--replay-icon">
+                        <v-icon class="player-overlay--play-icon">
                             mdi-replay
+                        </v-icon>
+                    </div>
+                </div>
+                <div
+                    v-if="
+                        resolvedType === 'video' &&
+                        !state.replay &&
+                        currentPercent === 0
+                    "
+                    class="player-overlay"
+                >
+                    <div class="player-overlay--icon">
+                        <v-icon class="player-overlay--play-icon">
+                            mdi-play
                         </v-icon>
                     </div>
                 </div>
@@ -1437,7 +1451,7 @@ export default {
     height: 0;
     text-align: center;
 }
-.player-overlay--replay-icon {
+.player-overlay--play-icon {
     color: #fff;
     font-size: 5rem;
 }


### PR DESCRIPTION
## Changes

-   Added play icon when the video is at 0% to be clear that the video player can be interacted with

## `npm run test` Results

```
Test Suites: 6 passed, 6 total
Tests:       24 passed, 24 total
Snapshots:   0 total
Time:        1.916 s
Ran all test suites.
```

## `npm run lint` Results

```
> @mindedge/vuetify-player@0.4.9 lint
> vue-cli-service lint

 DONE  No lint errors found!
```
