### PR TITLE
Play overlay fixes to only display when you're actually at 0 time and…

### DIFF
--- a/src/components/Media/Html5Player.vue
+++ b/src/components/Media/Html5Player.vue
@@ -20,6 +20,8 @@
                 <div
                     v-if="resolvedType === 'video' && state.replay"
                     class="player-overlay"
+                    role="button"
+                    @click="play"
                 >
                     <div class="player-overlay--icon">
                         <v-icon class="player-overlay--play-icon">
@@ -30,10 +32,13 @@
                 <div
                     v-if="
                         resolvedType === 'video' &&
+                        state.paused &&
                         !state.replay &&
-                        currentPercent === 0
+                        player.currentTime === 0
                     "
                     class="player-overlay"
+                    role="button"
+                    @click="play"
                 >
                     <div class="player-overlay--icon">
                         <v-icon class="player-overlay--play-icon">


### PR DESCRIPTION
## Changes

-   Change 1

## `npm run test` Results

```
Test Suites: 7 passed, 7 total
Tests:       25 passed, 25 total
Snapshots:   0 total
Time:        1.67 s, estimated 2 s
Ran all test suites.
```

## `npm run lint` Results

```
> @mindedge/vuetify-player@0.5.0 lint
> vue-cli-service lint

 DONE  No lint errors found!
```
