### PR TITLE
Allow multiple tracks with the same language code

### DIFF
--- a/src/components/Media/Html5Player.vue
+++ b/src/components/Media/Html5Player.vue
@@ -281,16 +281,16 @@
                                         <v-list>
                                             <v-list-item-group>
                                                 <v-list-item
-                                                    v-for="track in current.tracks"
-                                                    :key="track.srclang"
+                                                    v-for="(track, index) in current.tracks"
+                                                    :key="'track-' + index"
                                                     @click="
-                                                        onSelectTrack(
-                                                            track.srclang
+                                                        onSelectTrackByIndex(
+                                                            index
                                                         )
                                                     "
                                                 >
                                                     <v-list-item-title>{{
-                                                        track.srclang
+                                                        track.label || track.srclang
                                                     }}</v-list-item-title>
                                                 </v-list-item>
                                             </v-list-item-group>
@@ -1009,7 +1009,32 @@ export default {
             }, 50)
         },
         /**
-         * Select a specific track by lang
+         * Select a specific track by index (supports multiple tracks with same language)
+         *
+         * @param Number index The track index to activate
+         * @param String mode The track mode ('showing', 'hidden', 'disabled')
+         */
+        onSelectTrackByIndex(index, mode = 'showing') {
+            if (this.player.textTracks && this.player.textTracks.length > 0) {
+                // Disable all tracks first
+                for (let i = 0; i < this.player.textTracks.length; i++) {
+                    this.player.textTracks[i].mode = 'disabled'
+                }
+                
+                // Enable the selected track
+                if (this.player.textTracks[index]) {
+                    this.player.textTracks[index].mode = mode
+                    this.state.ccLang = this.player.textTracks[index].language
+                    
+                    this.setCues(this.player.textTracks[index])
+                    
+                    // Emit the current track
+                    this.$emit('trackchange', this.player.textTracks[index])
+                }
+            }
+        },
+        /**
+         * Select a specific track by lang (kept for backward compatibility)
          *
          * @param String|null lang The lang to load. Eg en-US, sv-SE, etc. Pass nothing / null to turn off captions
          */

--- a/src/components/Media/Html5Player.vue
+++ b/src/components/Media/Html5Player.vue
@@ -281,7 +281,9 @@
                                         <v-list>
                                             <v-list-item-group>
                                                 <v-list-item
-                                                    v-for="(track, index) in current.tracks"
+                                                    v-for="(
+                                                        track, index
+                                                    ) in current.tracks"
                                                     :key="'track-' + index"
                                                     @click="
                                                         onSelectTrackByIndex(
@@ -290,7 +292,8 @@
                                                     "
                                                 >
                                                     <v-list-item-title>{{
-                                                        track.label || track.srclang
+                                                        track.label ||
+                                                        track.srclang
                                                     }}</v-list-item-title>
                                                 </v-list-item>
                                             </v-list-item-group>
@@ -1020,14 +1023,14 @@ export default {
                 for (let i = 0; i < this.player.textTracks.length; i++) {
                     this.player.textTracks[i].mode = 'disabled'
                 }
-                
+
                 // Enable the selected track
                 if (this.player.textTracks[index]) {
                     this.player.textTracks[index].mode = mode
                     this.state.ccLang = this.player.textTracks[index].language
-                    
+
                     this.setCues(this.player.textTracks[index])
-                    
+
                     // Emit the current track
                     this.$emit('trackchange', this.player.textTracks[index])
                 }


### PR DESCRIPTION
## Changes

-   Allow multiple tracks with the same language code. Before it was keyed off the language instead of the index.

## `npm run test` Results

```
Test Suites: 7 passed, 7 total
Tests:       25 passed, 25 total
Snapshots:   0 total
Time:        1.757 s
Ran all test suites.
```

## `npm run lint` Results

```
> @mindedge/vuetify-player@0.5.1 lint
> vue-cli-service lint

Browserslist: caniuse-lite is outdated. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
 DONE  No lint errors found!
```
